### PR TITLE
Fix Dialog Position Bug

### DIFF
--- a/web/src/SecureVote/Components/UI/Dialog.elm
+++ b/web/src/SecureVote/Components/UI/Dialog.elm
@@ -42,6 +42,7 @@ dialog model =
         -- possible flex attrs: flex flex-column justify-between
         [ cs "overflow-scroll w-75 w-50-l"
         , css "max-height" "75%"
+        , css "top" "10%"
         ]
         -- span here fixes graphical error on safari
         [ Dialog.title [] [ span [] [ text model.dialogHtml.title ] ]


### PR DESCRIPTION
Couldn't figure out a way to load the content of the Dialog before rendering the Dialog so instead I just locked the top of the dialog to 10% of screen height so that the dialog never appears half off screen (since the max height of the Dialog is 75% of screen height).

Note: All dialogs will now appear near the top of the screen even small Dialogs.

<img width="1789" alt="screen shot 2017-10-26 at 2 01 32 pm" src="https://user-images.githubusercontent.com/23013276/32033088-4450c524-ba56-11e7-9a99-dba34e994707.png">
<img width="1789" alt="screen shot 2017-10-26 at 2 01 24 pm" src="https://user-images.githubusercontent.com/23013276/32033089-44aece4e-ba56-11e7-9b92-93f4a9ca0998.png">
<img width="1789" alt="screen shot 2017-10-26 at 2 01 11 pm" src="https://user-images.githubusercontent.com/23013276/32033090-450c2ff8-ba56-11e7-8d7c-b253f839e51e.png">
