### PR TITLE
Fix for buttons not working on iOS

### DIFF
--- a/web/js/birds.js
+++ b/web/js/birds.js
@@ -160,9 +160,10 @@ function init() {
 
     initComputeRenderer();
 
-    document.addEventListener('mousemove', onDocumentMouseMove, false);
-    document.addEventListener('touchstart', onDocumentTouchStart, false);
-    document.addEventListener('touchmove', onDocumentTouchMove, false);
+    // [TS] These event listeners override default functionality on iOS and cause all buttons to become unresponsive.
+    // document.addEventListener('mousemove', onDocumentMouseMove, false);
+    // document.addEventListener('touchstart', onDocumentTouchStart, false);
+    // document.addEventListener('touchmove', onDocumentTouchMove, false);
 
     //
 


### PR DESCRIPTION
This PR does however disable mouse interactions with the birds on desktop. There probably is a better way to fix this issue, but this is the easiest for now.